### PR TITLE
fix path for a build

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -111,8 +111,8 @@ func (jenkins *Jenkins) GetBuild(job Job, number int) (build Build, err error) {
 // Params can be nil.
 func (jenkins *Jenkins) Build(job Job, params url.Values) error {
 	if params == nil {
-		return jenkins.post(fmt.Sprintf("/job/%s/buildWithParameters", job.Name), params, nil)
-	} else {
 		return jenkins.post(fmt.Sprintf("/job/%s/build", job.Name), params, nil)
+	} else {
+		return jenkins.post(fmt.Sprintf("/job/%s/buildWithParameters", job.Name), params, nil)
 	}
 }


### PR DESCRIPTION
/buildWithParameters is only correct if the build is parameterised (i.e.
if params is not nil). If params is nil, we should be hitting /build on
Jenkins.

Without this fix in place, it looks like the build succeeded (no error is returned), but when then I try to request it by ID it fails.
