### PR TITLE
support getting the console output for a build

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -119,7 +119,7 @@ func (jenkins *Jenkins) Build(job Job, params url.Values) error {
 
 // Get the console output from a build.
 func (jenkins *Jenkins) GetBuildConsoleOutput(build Build) ([]byte, error) {
-	requestUrl := fmt.Sprintf("%s/logText/progressiveText?start=0", build.Url)
+	requestUrl := fmt.Sprintf("%s/consoleText", build.Url)
 	req, err := http.NewRequest("GET", requestUrl, nil)
 	if err != nil {
 		return nil, err

--- a/jenkins.go
+++ b/jenkins.go
@@ -116,3 +116,20 @@ func (jenkins *Jenkins) Build(job Job, params url.Values) error {
 		return jenkins.post(fmt.Sprintf("/job/%s/buildWithParameters", job.Name), params, nil)
 	}
 }
+
+// Get the console output from a build.
+func (jenkins *Jenkins) GetBuildConsoleOutput(build Build) ([]byte, error) {
+	requestUrl := fmt.Sprintf("%s/logText/progressiveText?start=0", build.Url)
+	req, err := http.NewRequest("GET", requestUrl, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := jenkins.sendRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+	return ioutil.ReadAll(res.Body)
+}


### PR DESCRIPTION
This adds support for getting console output from a build.

I elected not to support offsets as it added needless complexity.

Instead of using the `jenkins.get()` helper which builds the URL, I had to just use the `buildUrl` property on the Build object - otherwise it's difficult to infer the correct URL.