### PR TITLE
bugfix GetJobs always return empty array

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -68,7 +68,6 @@ func (jenkins *Jenkins) get(path string, params url.Values, body interface{}) (e
 	if err != nil {
 		return
 	}
-
 	return jenkins.parseResponse(resp, body)
 }
 
@@ -88,14 +87,12 @@ func (jenkins *Jenkins) post(path string, params url.Values, body interface{}) (
 }
 
 // GetJobs returns all jobs you can read.
-func (jenkins *Jenkins) GetJobs() (jobs []Job, err error) {
+func (jenkins *Jenkins) GetJobs() ([]Job, error) {
 	var payload = struct {
 		Jobs []Job `json:"jobs"`
-	}{
-		Jobs: jobs,
-	}
-	err = jenkins.get("", nil, &payload)
-	return
+	}{}
+	err := jenkins.get("", nil, &payload)
+	return payload.Jobs, err
 }
 
 // GetJob returns a job which has specified name.

--- a/jenkins_test.go
+++ b/jenkins_test.go
@@ -1,0 +1,24 @@
+package gojenkins
+
+import (
+	"testing"
+)
+
+func NewJenkinsWithTestData() *Jenkins {
+	var auth Auth
+	return NewJenkins(&auth, "http://example.com")
+}
+
+func Test(t *testing.T) {
+	jenkins := NewJenkinsWithTestData()
+
+	jobs, err := jenkins.GetJobs()
+
+	if err != nil {
+		t.Errorf("error %v\n", err)
+	}
+
+	if len(jobs) == 0 {
+		t.Errorf("return no jobs\n")
+	}
+}


### PR DESCRIPTION
Jenkins.GetJobs() return always empty array.

A get() method assign data to payload.Jobs, but it isn't same object to jobs.
So this method always return empty array.

```go
func (jenkins *Jenkins) GetJobs() (jobs []Job, err error) {
 	var payload = struct {
 		Jobs []Job `json:"jobs"`
	}{
		Jobs: jobs, // copy jobs to payload.Jobs
	}
	err = jenkins.get("", nil, &payload)
	fmt.Printf("%v\n", &jobs == &(payload.Jobs)) // not same object
	return
}
```