### PR TITLE
Add goals xml tag when creating a new jenkins job item.

### DIFF
--- a/job.go
+++ b/job.go
@@ -48,6 +48,7 @@ type MavenJobItem struct {
 	BlockBuildWhenUpstreamBuilding   string               `xml:"blockBuildWhenUpstreamBuilding"`
 	Triggers                         Triggers             `xml:"triggers"`
 	ConcurrentBuild                  string               `xml:"concurrentBuild"`
+	Goals                            string               `xml:"goals"`
 	AggregatorStyleBuild             string               `xml:"aggregatorStyleBuild"`
 	IncrementalBuild                 string               `xml:"incrementalBuild"`
 	IgnoreUpstremChanges             string               `xml:"ignoreUpstremChanges"`


### PR DESCRIPTION
This is useful for when you want to create a maven job item.
The 'goals' tag refers to maven goals.
e.g. 
``` 
mvn clean install
```