### PR TITLE
Added logic to add a job item to a jenkins 'view'

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -160,6 +160,12 @@ func (jenkins *Jenkins) CreateJob(mavenJobItem MavenJobItem, jobName string) err
 	return jenkins.postXml("/createItem", params, reader, nil)
 }
 
+// Add job to view
+func (jenkins *Jenkins) AddJobToView(viewName string, job Job) error {
+	params := url.Values{"name": []string{job.Name}}
+	return jenkins.post(fmt.Sprintf("/view/%s/addJobToView", viewName), params, nil)
+}
+
 // Create a new build for this job.
 // Params can be nil.
 func (jenkins *Jenkins) Build(job Job, params url.Values) error {

--- a/jenkins_test.go
+++ b/jenkins_test.go
@@ -24,6 +24,32 @@ func Test(t *testing.T) {
 	}
 }
 
+func TestAddJobToView(t *testing.T) {
+	jenkins := NewJenkinsWithTestData()
+
+	scm := Scm{
+		Class: "hudson.scm.SubversionSCM",
+	}
+	jobItem := MavenJobItem{
+		Plugin:               "maven-plugin@2.7.1",
+		Description:          "test description",
+		Scm:                  scm,
+		Triggers:             Triggers{},
+		RunPostStepsIfResult: RunPostStepsIfResult{},
+		Settings:             JobSettings{Class: "jenkins.mvn.DefaultSettingsProvider"},
+		GlobalSettings:       JobSettings{Class: "jenkins.mvn.DefaultSettingsProvider"},
+	}
+	newJobName := fmt.Sprintf("test-with-view-%d", time.Now().UnixNano())
+	jenkins.CreateJob(jobItem, newJobName)
+
+	job := Job{Name: newJobName}
+	err := jenkins.AddJobToView("test", job)
+
+	if err != nil {
+		t.Errorf("error %v\n", err)
+	}
+}
+
 func TestCreateJobItem(t *testing.T) {
 	jenkins := NewJenkinsWithTestData()
 	scm := Scm{


### PR DESCRIPTION
Allow adding many jobs to a single view.
The 'add job to view' Jenkins API assumes the view already exists. (strangely It returns a 200 if you try to add a job to a view that doesn't exist.)

There appears to be a [way] (https://issues.jenkins-ci.org/browse/JENKINS-8927) to 'create' a jenkins view. Might implement as a separate PR.
