### PR TITLE
Fixed bug when creating a view. The status column isn't set.

### DIFF
--- a/jenkins_test.go
+++ b/jenkins_test.go
@@ -40,10 +40,12 @@ func TestAddJobToView(t *testing.T) {
 		GlobalSettings:       JobSettings{Class: "jenkins.mvn.DefaultSettingsProvider"},
 	}
 	newJobName := fmt.Sprintf("test-with-view-%d", time.Now().UnixNano())
+	newViewName := fmt.Sprintf("test-view-%d", time.Now().UnixNano())
 	jenkins.CreateJob(jobItem, newJobName)
+	jenkins.CreateView(NewListView(newViewName))
 
 	job := Job{Name: newJobName}
-	err := jenkins.AddJobToView("test", job)
+	err := jenkins.AddJobToView(newViewName, job)
 
 	if err != nil {
 		t.Errorf("error %v\n", err)

--- a/listview.go
+++ b/listview.go
@@ -24,24 +24,24 @@ type Columns struct {
 }
 
 type StatusColumn struct {
-	XMLName xml.Name `xml:"hudson.view.StatusColumn"`
+	XMLName xml.Name `xml:"hudson.views.StatusColumn"`
 }
 type WeatherColumn struct {
-	XMLName xml.Name `xml:"hudson.view.WeatherColumn"`
+	XMLName xml.Name `xml:"hudson.views.WeatherColumn"`
 }
 
 type JobColumn struct {
-	XMLName xml.Name `xml:"hudson.view.JobColumn"`
+	XMLName xml.Name `xml:"hudson.views.JobColumn"`
 }
 type LastSuccessColumn struct {
-	XMLName xml.Name `xml:"hudson.view.LastSuccessColumn"`
+	XMLName xml.Name `xml:"hudson.views.LastSuccessColumn"`
 }
 type LastFailureColumn struct {
-	XMLName xml.Name `xml:"hudson.view.LastFailureColumn"`
+	XMLName xml.Name `xml:"hudson.views.LastFailureColumn"`
 }
 type LastDurationColumn struct {
-	XMLName xml.Name `xml:"hudson.view.LastDurationColumn"`
+	XMLName xml.Name `xml:"hudson.views.LastDurationColumn"`
 }
 type BuildButtonColumn struct {
-	XMLName xml.Name `xml:"hudson.view.BuildButtonColumn"`
+	XMLName xml.Name `xml:"hudson.views.BuildButtonColumn"`
 }


### PR DESCRIPTION
The xml name for view columns had a typo (it was missing a 's'). This results in the view being created without the desired status columns.