### PR TITLE
Added support to get config.xml and Git repo

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -90,6 +90,20 @@ func (jenkins *Jenkins) get(path string, params url.Values, body interface{}) (e
 	return jenkins.parseResponse(resp, body)
 }
 
+func (jenkins *Jenkins) getXml(path string, params url.Values, body interface{}) (err error) {
+	requestUrl := jenkins.buildUrl(path, params)
+	req, err := http.NewRequest("GET", requestUrl, nil)
+	if err != nil {
+		return
+	}
+
+	resp, err := jenkins.sendRequest(req)
+	if err != nil {
+		return
+	}
+	return jenkins.parseXmlResponse(resp, body)
+}
+
 func (jenkins *Jenkins) post(path string, params url.Values, body interface{}) (err error) {
 	requestUrl := jenkins.buildUrl(path, params)
 	req, err := http.NewRequest("POST", requestUrl, nil)
@@ -142,6 +156,12 @@ func (jenkins *Jenkins) GetJobs() ([]Job, error) {
 // GetJob returns a job which has specified name.
 func (jenkins *Jenkins) GetJob(name string) (job Job, err error) {
 	err = jenkins.get(fmt.Sprintf("/job/%s", name), nil, &job)
+	return
+}
+
+//GetJobConfig returns a maven job, has the one used to create Maven job
+func (jenkins *Jenkins) GetJobConfig(name string) (job MavenJobItem, err error) {
+	err = jenkins.getXml(fmt.Sprintf("/job/%s/config.xml", name), nil, &job)
 	return
 }
 

--- a/jenkins_test.go
+++ b/jenkins_test.go
@@ -66,16 +66,18 @@ func TestCreateView(t *testing.T) {
 func TestCreateJobItem(t *testing.T) {
 	jenkins := NewJenkinsWithTestData()
 	scm := Scm{
-		Locations: Locations{
-			[]Location{
-				ScmSvnLocation{IgnoreExternalsOption: "false", DepthOption: "infinity", Local: ".", Remote: "http://some-svn-url"},
+		ScmContent: ScmSvn{
+			Locations: Locations{
+				[]ScmSvnLocation{
+					ScmSvnLocation{IgnoreExternalsOption: "false", DepthOption: "infinity", Local: ".", Remote: "http://some-svn-url"},
+				},
 			},
+			IgnoreDirPropChanges: "false",
+			FilterChanglog:       "false",
+			WorkspaceUpdater:     WorkspaceUpdater{Class: "hudson.scm.subversion.UpdateUpdater"},
 		},
-		Class:                "hudson.scm.SubversionSCM",
-		Plugin:               "subversion@1.54",
-		IgnoreDirPropChanges: "false",
-		FilterChanglog:       "false",
-		WorkspaceUpdater:     WorkspaceUpdater{Class: "hudson.scm.subversion.UpdateUpdater"},
+		Class:  "hudson.scm.SubversionSCM",
+		Plugin: "subversion@1.54",
 	}
 	triggers := Triggers{[]Trigger{ScmTrigger{}}}
 	postStep := RunPostStepsIfResult{Name: "FAILURE", Ordinal: "2", Color: "RED", CompleteBuild: "true"}


### PR DESCRIPTION
Config.xml can be read from multiple api's in Jenkins inclusive Job. It display the same information used to create the job at the first place.
Added support to read config.xml to MavenJobItem struct. 
Corrected SVN SCM to support correctly xml.Unmarshal and added Git as alternative SCM.