### PR TITLE
Allow Auth to be nil for jenkins

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -42,7 +42,9 @@ func (jenkins *Jenkins) buildUrl(path string, params url.Values) (requestUrl str
 }
 
 func (jenkins *Jenkins) sendRequest(req *http.Request) (*http.Response, error) {
-	req.SetBasicAuth(jenkins.auth.Username, jenkins.auth.ApiToken)
+	if jenkins.auth != nil {
+		req.SetBasicAuth(jenkins.auth.Username, jenkins.auth.ApiToken)
+	}
 	return http.DefaultClient.Do(req)
 }
 


### PR DESCRIPTION
Currently there is no way to set this library to use anonymous access - errors are caused if the Auth is set to nil & setting username and token to the empty string does not behave as required. This small change allows using against an anonymous Jenkins server by setting the Auth passed to NewJenkins to nil.