### PR TITLE
Implements 'SetBuildDescription', adds to structs for UpstreamCause data

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -247,6 +247,27 @@ func (jenkins *Jenkins) GetArtifact(build Build, artifact Artifact) ([]byte, err
 	return ioutil.ReadAll(res.Body)
 }
 
+// SetBuildDescription sets the description of a build
+func (jenkins *Jenkins) SetBuildDescription(build Build, description string) error {
+	requestUrl := fmt.Sprintf("%ssubmitDescription?description=%s", build.Url, url.QueryEscape(description))
+	req, err := http.NewRequest("GET", requestUrl, nil)
+	if err != nil {
+		return err
+	}
+
+	res, err := jenkins.sendRequest(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		return fmt.Errorf("Unexpected response: expected '200' but received '%d'", res.StatusCode)
+	}
+
+	return nil
+}
+
 // GetComputerObject returns the main ComputerObject
 func (jenkins *Jenkins) GetComputerObject() (co ComputerObject, err error) {
 	err = jenkins.get(fmt.Sprintf("/computer"), nil, &co)

--- a/job.go
+++ b/job.go
@@ -28,11 +28,6 @@ type Build struct {
 	Actions   []Action   `json:"actions"`
 }
 
-type Parameter struct {
-	Name  string `json:"Name"`
-	Value string `json:"Value"`
-}
-
 type UpstreamCause struct {
 	ShortDescription string `json:"shortDescription"`
 	UpstreamBuild    int    `json:"UpstreamBuild"`

--- a/job.go
+++ b/job.go
@@ -30,9 +30,9 @@ type Build struct {
 
 type UpstreamCause struct {
 	ShortDescription string `json:"shortDescription"`
-	UpstreamBuild    int    `json:"UpstreamBuild"`
-	UpstreamProject  string `json:"UpstreamProject"`
-	UpstreamUrl      string `json:"UpstreamUrl"`
+	UpstreamBuild    int    `json:"upstreamBuild"`
+	UpstreamProject  string `json:"upstreamProject"`
+	UpstreamUrl      string `json:"upstreamUrl"`
 }
 
 type Job struct {

--- a/job.go
+++ b/job.go
@@ -25,6 +25,19 @@ type Build struct {
 	Result   string `json:"result"`
 
 	Artifacts []Artifact `json:"artifacts"`
+	Actions   []Action   `json:"actions"`
+}
+
+type Parameter struct {
+	Name  string `json:"Name"`
+	Value string `json:"Value"`
+}
+
+type UpstreamCause struct {
+	ShortDescription string `json:"shortDescription"`
+	UpstreamBuild    int    `json:"UpstreamBuild"`
+	UpstreamProject  string `json:"UpstreamProject"`
+	UpstreamUrl      string `json:"UpstreamUrl"`
 }
 
 type Job struct {

--- a/queue.go
+++ b/queue.go
@@ -20,13 +20,15 @@ type Item struct {
 }
 
 type Action struct {
-	Causes []Cause
+	Parameters []Parameter `json:"parameters"`
+	Causes     []Cause     `json:"causes"`
 }
 
 type Cause struct {
 	ShortDescription string `json:"shortDescription"`
 	UserId           string `json:"userId"`
 	UserName         string `json:"userName"`
+	UpstreamCause
 }
 
 type Task struct {

--- a/queue.go
+++ b/queue.go
@@ -20,8 +20,7 @@ type Item struct {
 }
 
 type Action struct {
-	Parameters []Parameter `json:"parameters"`
-	Causes     []Cause     `json:"causes"`
+	Causes []Cause `json:"causes"`
 }
 
 type Cause struct {


### PR DESCRIPTION
Implements 'SetBuildDescription' and adds additional data to structs related to Upstream build cause. Allows you to inspect a build and get relevant information from the upstream build.