### PR TITLE
Determine build url based on existence of job params

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -206,10 +206,10 @@ func (jenkins *Jenkins) CreateView(listView ListView) error {
 // Create a new build for this job.
 // Params can be nil.
 func (jenkins *Jenkins) Build(job Job, params url.Values) error {
-	if params == nil {
-		return jenkins.post(fmt.Sprintf("/job/%s/build", job.Name), params, nil)
-	} else {
+	if hasParams(job) {
 		return jenkins.post(fmt.Sprintf("/job/%s/buildWithParameters", job.Name), params, nil)
+	} else {
+		return jenkins.post(fmt.Sprintf("/job/%s/build", job.Name), params, nil)
 	}
 }
 
@@ -293,4 +293,14 @@ func (jenkins *Jenkins) GetComputers() ([]Computer, error) {
 func (jenkins *Jenkins) GetComputer(name string) (computer Computer, err error) {
 	err = jenkins.get(fmt.Sprintf("/computer/%s", name), nil, &computer)
 	return
+}
+
+// hasParams returns a boolean value indicating if the job is parameterized
+func hasParams(job Job) bool {
+	for _, action := range job.Actions {
+		if len(action.ParameterDefinitions) > 0 {
+			return true
+		}
+	}
+	return false
 }

--- a/job.go
+++ b/job.go
@@ -36,9 +36,10 @@ type UpstreamCause struct {
 }
 
 type Job struct {
-	Name  string `json:"name"`
-	Url   string `json:"url"`
-	Color string `json:"color"`
+	Actions []Action `json:"actions"`
+	Name    string   `json:"name"`
+	Url     string   `json:"url"`
+	Color   string   `json:"color"`
 
 	Buildable    bool     `json:"buildable"`
 	DisplayName  string   `json:"displayName"`

--- a/queue.go
+++ b/queue.go
@@ -20,7 +20,8 @@ type Item struct {
 }
 
 type Action struct {
-	Causes []Cause `json:"causes"`
+	Causes               []Cause               `json:"causes"`
+	ParameterDefinitions []ParameterDefinition `json:"parameterDefinitions"`
 }
 
 type Cause struct {
@@ -28,6 +29,10 @@ type Cause struct {
 	UserId           string `json:"userId"`
 	UserName         string `json:"userName"`
 	UpstreamCause
+}
+
+type ParameterDefinition struct {
+	Name string `json:"name"`
 }
 
 type Task struct {


### PR DESCRIPTION
Updates `Build` to set the target url based on the existence of job parameters instead of the params passed in by the user. This allows for triggering a build with parameters using the default parameters.