### PR TITLE
Support for QueueID, getting Builds summary from Job

### DIFF
--- a/job.go
+++ b/job.go
@@ -30,6 +30,12 @@ type Build struct {
 	QueueId int `json:"queueId"`
 }
 
+// The summary of a build that is returned from the Job endpoint.
+type BuildShort struct {
+	Number int    `json:"number"`
+	Url    string `json:"url"`
+}
+
 type UpstreamCause struct {
 	ShortDescription string `json:"shortDescription"`
 	UpstreamBuild    int    `json:"upstreamBuild"`
@@ -43,10 +49,11 @@ type Job struct {
 	Url     string   `json:"url"`
 	Color   string   `json:"color"`
 
-	Buildable    bool     `json:"buildable"`
-	DisplayName  string   `json:"displayName"`
-	Description  string   `json:"description"`
-	HealthReport []Health `json:"healthReport"`
+	Buildable    bool         `json:"buildable"`
+	Builds       []BuildShort `json:"builds"`
+	DisplayName  string       `json:"displayName"`
+	Description  string       `json:"description"`
+	HealthReport []Health     `json:"healthReport"`
 
 	LastCompletedBuild    Build `json:"lastCompletedBuild"`
 	LastFailedBuild       Build `json:"lastFailedBuild"`

--- a/job.go
+++ b/job.go
@@ -26,6 +26,8 @@ type Build struct {
 
 	Artifacts []Artifact `json:"artifacts"`
 	Actions   []Action   `json:"actions"`
+
+	QueueId int `json:"queueId"`
 }
 
 type UpstreamCause struct {


### PR DESCRIPTION
- 40b9088: allows us to get back the queue ID when we submit a job, which means we can return that to the client
- dadc58b: lets us figure out which build corresponds to a known queue ID
- 86601b5: lets us get the full list of builds for a Job, so that we can look up the jobs for ID to find the one with the queue ID we're looking for

---

The main impact of this change aside from just adding missing fields to structs is the change to the signature of `Build()`: since a successful call now returns two arguments including the Queue ID of the new build, this will break existing clients. It's trivial to fix, but if the maintainer(s) would prefer to avoid that I can change this PR to add a new `Build()` variant with the two return values.
