### PR TITLE
Modify typo

### DIFF
--- a/jenkins_test.go
+++ b/jenkins_test.go
@@ -73,7 +73,7 @@ func TestCreateJobItem(t *testing.T) {
 				},
 			},
 			IgnoreDirPropChanges: "false",
-			FilterChanglog:       "false",
+			FilterChangelog:      "false",
 			WorkspaceUpdater:     WorkspaceUpdater{Class: "hudson.scm.subversion.UpdateUpdater"},
 		},
 		Class:  "hudson.scm.SubversionSCM",

--- a/job.go
+++ b/job.go
@@ -109,7 +109,7 @@ type ScmSvn struct {
 	ExcludedCommitMessages string           `xml:"excludedCommitMessages"`
 	WorkspaceUpdater       WorkspaceUpdater `xml:"workspaceUpdater"`
 	IgnoreDirPropChanges   string           `xml:"ignoreDirPropChanges"`
-	FilterChanglog         string           `xml:"filterChangelog"`
+	FilterChangelog        string           `xml:"filterChangelog"`
 }
 
 type WorkspaceUpdater struct {


### PR DESCRIPTION
```ScmSvn``` struct has typo error. ```FilterChanglog``` -> ```FilterChangelog```
