### PR TITLE
Add support for for CSRF prevention

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -17,6 +17,11 @@ type Auth struct {
 	ApiToken string
 }
 
+type CrumbIssuer struct {
+	Crumb             string `json:"crumb"`
+	CrumbRequestField string `json:"crumbRequestField"`
+}
+
 type Jenkins struct {
 	auth    *Auth
 	baseUrl string
@@ -39,6 +44,14 @@ func (jenkins *Jenkins) buildUrl(path string, params url.Values) (requestUrl str
 	}
 
 	return
+}
+
+// getCrumb returns a csrf crumb for post.
+func (jenkins *Jenkins) getCrumb() (CrumbIssuer, error) {
+	payload := CrumbIssuer{}
+	err := jenkins.get("/crumbIssuer", nil, &payload)
+
+	return payload, err
 }
 
 func (jenkins *Jenkins) sendRequest(req *http.Request) (*http.Response, error) {
@@ -107,6 +120,11 @@ func (jenkins *Jenkins) getXml(path string, params url.Values, body interface{})
 }
 
 func (jenkins *Jenkins) post(path string, params url.Values, body interface{}) (err error) {
+
+	// add a CSRF crumb
+	crumb, _ := jenkins.getCrumb()
+	params.Add(crumb.CrumbRequestField, crumb.Crumb);
+
 	requestUrl := jenkins.buildUrl(path, params)
 	req, err := http.NewRequest("POST", requestUrl, nil)
 	if err != nil {


### PR DESCRIPTION
Try to obtain a CSRF prevention crump from Jenkins and add it
to all POST requests. If CSRF prevention is disabled an empty
crumb will be added to the POST request.

I basically just used the code that was suggested by @woohgit

Resolves yosida95/golang-jenkins#40