### PR TITLE
Call Jenkins.EnhanceClient to replace http.DefaultClient

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -20,13 +20,20 @@ type Auth struct {
 type Jenkins struct {
 	auth    *Auth
 	baseUrl string
+	client  *http.Client
 }
 
 func NewJenkins(auth *Auth, baseUrl string) *Jenkins {
 	return &Jenkins{
 		auth:    auth,
 		baseUrl: baseUrl,
+		client:  http.DefaultClient,
 	}
+}
+
+// EnhanceClient with timeouts or insecure transport, etc.
+func (jenkins *Jenkins) EnhanceClient(client *http.Client) {
+	jenkins.client = client
 }
 
 func (jenkins *Jenkins) buildUrl(path string, params url.Values) (requestUrl string) {
@@ -45,7 +52,7 @@ func (jenkins *Jenkins) sendRequest(req *http.Request) (*http.Response, error) {
 	if jenkins.auth != nil {
 		req.SetBasicAuth(jenkins.auth.Username, jenkins.auth.ApiToken)
 	}
-	return http.DefaultClient.Do(req)
+	return jenkins.client.Do(req)
 }
 
 func (jenkins *Jenkins) parseXmlResponse(resp *http.Response, body interface{}) (err error) {

--- a/jenkins.go
+++ b/jenkins.go
@@ -31,8 +31,8 @@ func NewJenkins(auth *Auth, baseUrl string) *Jenkins {
 	}
 }
 
-// EnhanceClient with timeouts or insecure transport, etc.
-func (jenkins *Jenkins) EnhanceClient(client *http.Client) {
+// SetHTTPClient with timeouts or insecure transport, etc.
+func (jenkins *Jenkins) SetHTTPClient(client *http.Client) {
 	jenkins.client = client
 }
 


### PR DESCRIPTION
Allows for custom time-out, disable TLS , etc.

fixes #42 