### PR TITLE
GetJob deserializes `parameters` from Build response

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -21,6 +21,7 @@ type Item struct {
 
 type Action struct {
 	Causes               []Cause               `json:"causes"`
+	Parameter            []Parameter           `json:"parameters"`
 	ParameterDefinitions []ParameterDefinition `json:"parameterDefinitions"`
 }
 
@@ -33,6 +34,12 @@ type Cause struct {
 
 type ParameterDefinition struct {
 	Name string `json:"name"`
+}
+
+// Parameter for a build
+type Parameter struct {
+	Name  string      `json:"name"`
+	Value interface{} `json:"value"`
 }
 
 type Task struct {


### PR DESCRIPTION
Enable access to the Parameter name/values from GetJob
fixes #44