### PR TITLE
Add Class to Computer struct

### DIFF
--- a/computer.go
+++ b/computer.go
@@ -9,6 +9,7 @@ type ComputerObject struct {
 
 type Computer struct {
 	Actions             []struct{} `json:"actions"`
+	Class               string     `json:"_class"`
 	DisplayName         string     `json:"displayName"`
 	Executors           []struct{} `json:"executors"`
 	Idle                bool       `json:"idle"`


### PR DESCRIPTION
Includes `Class` in the `Computer` struct - we use this for filtering on specific types of nodes (e.g. `"_class":"hudson.plugins.ec2.EC2Computer"`) on a given Jenkins host.