### PR TITLE
Add Context Support to GetJob and GetBuild

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -170,8 +170,8 @@ func (jenkins *Jenkins) GetJobs() ([]Job, error) {
 }
 
 // GetJob returns a job which has specified name.
-func (jenkins *Jenkins) GetJob(name string) (job Job, err error) {
-	err = jenkins.get(fmt.Sprintf("/job/%s", name), nil, &job)
+func (jenkins *Jenkins) GetJob(name string, params url.Values) (job Job, err error) {
+	err = jenkins.get(fmt.Sprintf("/job/%s", name), params, &job)
 	return
 }
 

--- a/jenkins.go
+++ b/jenkins.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 type Auth struct {
@@ -107,10 +108,20 @@ func (jenkins *Jenkins) getXml(path string, params url.Values, body interface{})
 }
 
 func (jenkins *Jenkins) post(path string, params url.Values, body interface{}) (err error) {
-	requestUrl := jenkins.buildUrl(path, params)
-	req, err := http.NewRequest("POST", requestUrl, nil)
+	requestUrl := jenkins.buildUrl(path, nil)
+
+	var bodyReader io.Reader
+	if params != nil {
+		bodyReader = strings.NewReader(params.Encode())
+	}
+
+	req, err := http.NewRequest("POST", requestUrl, bodyReader)
 	if err != nil {
 		return
+	}
+
+	if params != nil {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	}
 
 	resp, err := jenkins.sendRequest(req)

--- a/job.go
+++ b/job.go
@@ -46,12 +46,13 @@ type Job struct {
 	Description  string   `json:"description"`
 	HealthReport []Health `json:"healthReport"`
 
-	LastCompletedBuild    Build `json:"lastCompletedBuild"`
-	LastFailedBuild       Build `json:"lastFailedBuild"`
-	LastStableBuild       Build `json:"lastStableBuild"`
-	LastSuccessfulBuild   Build `json:"lastSuccessfulBuild"`
-	LastUnstableBuild     Build `json:"lastUnstableBuild"`
-	LastUnsuccessfulBuild Build `json:"lastUnsuccessfulBuild"`
+	Builds                []Build `json:"builds"`
+	LastCompletedBuild    Build   `json:"lastCompletedBuild"`
+	LastFailedBuild       Build   `json:"lastFailedBuild"`
+	LastStableBuild       Build   `json:"lastStableBuild"`
+	LastSuccessfulBuild   Build   `json:"lastSuccessfulBuild"`
+	LastUnstableBuild     Build   `json:"lastUnstableBuild"`
+	LastUnsuccessfulBuild Build   `json:"lastUnsuccessfulBuild"`
 }
 
 type Health struct {

--- a/job.go
+++ b/job.go
@@ -36,6 +36,7 @@ type UpstreamCause struct {
 }
 
 type Job struct {
+	Class   string   `json:"_class"`
 	Actions []Action `json:"actions"`
 	Name    string   `json:"name"`
 	Url     string   `json:"url"`

--- a/queue.go
+++ b/queue.go
@@ -22,7 +22,7 @@ type Item struct {
 type Action struct {
 	Causes               []Cause               `json:"causes"`
 	ParameterDefinitions []ParameterDefinition `json:"parameterDefinitions"`
-	Parameters           []Parameter           `json:"parameter"`
+	Parameters           []Parameter           `json:"parameters"`
 }
 
 type Cause struct {

--- a/queue.go
+++ b/queue.go
@@ -37,8 +37,8 @@ type ParameterDefinition struct {
 }
 
 type Parameter struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
+	Name  string      `json:"name"`
+	Value interface{} `json:"value"`
 }
 
 type Task struct {

--- a/queue.go
+++ b/queue.go
@@ -22,6 +22,7 @@ type Item struct {
 type Action struct {
 	Causes               []Cause               `json:"causes"`
 	ParameterDefinitions []ParameterDefinition `json:"parameterDefinitions"`
+	Parameters           []Parameter           `json:"parameter"`
 }
 
 type Cause struct {
@@ -33,6 +34,11 @@ type Cause struct {
 
 type ParameterDefinition struct {
 	Name string `json:"name"`
+}
+
+type Parameter struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 type Task struct {


### PR DESCRIPTION
Adding new methods to support context support in underlying HTTP GET requests.
- GetJobWithContext
- GetBuildWithContext
- getWithContext

This allows timeout contexts to be used.